### PR TITLE
Trim the list of people of use minotar.net

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,33 +156,11 @@
     <hr>
 
     <ul>
-        <li><a href="http://www.minecraftforum.net/forum">Minecraft Forum</a><br>
-            Official Minecraft Forum!
-        </li>
-        <li><a href="http://bukkit.org/">Bukkit Forums</a><br>
-            Open Source Minecraft Server Software
-        </li>
-        <li>
-            <a href="http://buycraft.net/">BuyCraft</a>
-            The #1 Bukkit plugin for automatically processing donations.
-        </li>
-        <li><a href="http://webcraftdev.com">WebCraft</a><br>
-            #1 Bootstrap Minecraft Website Software/CMS.
-        </li>
-        <li><a href="http://www.planetminecraft.com/">PlanetMinecraft</a><br>
-            The largest Minecraft resource site.
-        </li>
         <li><a href="http://minecraft-seeds.net/">Minecraft-Seeds</a><br>
             Minecraft-Seeds.net collects and shares detailed Information about Minecraft Seeds.
         </li>
-        <li><a href="http://minecraft-skins.com/">Minecraft Skins</a><br>
-            The largest skin browsing site.
-        </li>
         <li><a href="http://yeahwh.at/">YEAHWH.AT?!</a><br>
             A large Minecraft server.
-        </li>
-        <li><a href="http://massivecraft.com/">MassiveCraft</a><br>
-            Massivecraft is a medieval fantasy role-playing Minecraft server.
         </li>
     </ul>
 
@@ -207,7 +185,7 @@
     <hr>
 
     <footer>
-        <p>Copyright 2013 &ndash; <a href="http://axxim.net">Axxim, LLC</a><br>
+        <p>Copyright 2014 &ndash; <a href="http://axxim.net">Axxim, LLC</a><br>
             Hosted by <a href="https://www.digitalocean.com/">DigitalOcean</a></p>
 
         <p>Source code is on <a href="https://github.com/minotar/minotar">GitHub</a></p>


### PR DESCRIPTION
Used @PaulBGD's PR https://github.com/minotar/minotar.net/pull/3 as a base and trimmed it further.
- www.minecraftforum.net - internal solution
- bukkit.org - assumed internal as well (wasn't sure where I was looking for avatars...)
- www.enjin.com - cravatar.eu
- www.buycraft.net - cravatar.eu
- webcraftdev.com - dead?
- www.planetminecraft.com - internal I believe
- minecraft-skins.com - dead?
- www.massivecraft.com - dynmap generated
