### PR TITLE
Further updates to layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link href="https://fonts.googleapis.com/css?family=Raleway:400,600,800" rel="stylesheet">
     <meta name="description" content="Minotar is an insanely fast service for turning your Minecraft skin into an Avatar. Easily embeddable and usable for your site, blog or plugin.">
     <meta name="author" content="Axxim, LLC">
-    <link rel="shortcut icon" href="https://minotar.net/avatar/d9135e082f2244c89cb0bee234155292/128.png">
+    <link rel="shortcut icon" href="https://minotar.net/avatar/d9135e082f2244c89cb0bee234155292/128">
     <link rel="canonical" href="https://minotar.net/" />    
 
     <style>
@@ -22,9 +22,8 @@
             min-height: 50vh;
         }
 
-        pre {
-            white-space: pre-wrap;
-            word-wrap: break-word;
+        .list {
+            padding-left: 10px;
         }
 
         ::selection {
@@ -47,38 +46,38 @@
                 <p class="f3 f2-ns fw6 mt1 mb5">An insanely fast and simple Minecraft avatar API</p>
 
                 <div class="flex flex-row pa2 br1 bg-dark-gray">
-                    <div class="mr3 dn db-ns">
-                        <img class="grow db br3" src="https://minotar.net/avatar/d9135e082f2244c89cb0bee234155292/64.png" alt="The Avatar of clone1018" title="clone1018">
+                    <div class="mr3">
+                        <img class="grow db br1 br3-l" src="https://minotar.net/avatar/d9135e082f2244c89cb0bee234155292/64" alt="The Avatar of clone1018" title="clone1018">
                     </div>
                     <div class="mr3">
-                        <img class="grown db br3" src="https://minotar.net/avatar/5c115ca73efd41178213a0aff8ef11e0/64.png" alt="The Avatar of LukeHandle" title="LukeHandle">
-                    </div>
-                    <div class="mr3">
-                        <img class="grown db br3" src="https://minotar.net/avatar/connor4312/64.png" alt="The Avatar of connor4312" title="connor4312">
-                    </div>
-                    <div class="mr3">
-                        <img class="grown db br3" src="https://minotar.net/avatar/2f3665cc5e29439bbd14cb6d3a6313a7/64.png" alt="The Avatar of lukegb" title="lukegb">
-                    </div>
-                    <div class="mr3">
-                        <img class="grown db br3" src="https://minotar.net/avatar/48a0a7e4d5594873a617dc189f76a8a1/64.png" alt="The Avatar of citricsquid" title="citricsquid">
-                    </div>
-                    <div class="mr3">
-                        <img class="grown db br3" src="https://minotar.net/avatar/e5eea5f735c444a28af9b2c867ade454/64.png" alt="The Avatar of KamalN" title="KamalN">
-                    </div>
-                    <div class="mr3">
-                        <img class="grown db br3" src="https://minotar.net/avatar/069a79f444e94726a5befca90e38aaf5/64.png" alt="The Avatar of Notch" title="Notch">
+                        <img class="grow db br1 br3-l" src="https://minotar.net/avatar/5c115ca73efd41178213a0aff8ef11e0/64" alt="The Avatar of LukeHandle" title="LukeHandle">
                     </div>
                     <div class="mr3 dn db-ns">
-                        <img class="grown db br3" src="https://minotar.net/avatar/0916866379734076877df789dd30340b/64.png" alt="The Avatar of Banxsi" title="Banxsi">
-                    </div>
-                    <div class="mr3 dn db-ns">
-                        <img class="grown db br3" src="https://minotar.net/avatar/472cdef3cef147a0a44a2ab7f5ce07f6/64.png" alt="The Avatar of externo6" title="externo6">
+                        <img class="grow db br1 br3-l" src="https://minotar.net/avatar/connor4312/64" alt="The Avatar of connor4312" title="connor4312">
                     </div>
                     <div class="mr3">
-                        <img class="grown db br3" src="https://minotar.net/avatar/0c035b597e1a42b0b31610c9343d34dd/64.png" alt="The Avatar of drupal" title="drupal">
+                        <img class="grow db br1 br3-l" src="https://minotar.net/avatar/2f3665cc5e29439bbd14cb6d3a6313a7/64" alt="The Avatar of lukegb" title="lukegb">
+                    </div>
+                    <div class="mr3">
+                        <img class="grow db br1 br3-l" src="https://minotar.net/avatar/48a0a7e4d5594873a617dc189f76a8a1/64" alt="The Avatar of citricsquid" title="citricsquid">
+                    </div>
+                    <div class="mr3">
+                        <img class="grow db br1 br3-l" src="https://minotar.net/avatar/e5eea5f735c444a28af9b2c867ade454/64" alt="The Avatar of KamalN" title="KamalN">
+                    </div>
+                    <div class="mr3">
+                        <img class="grow db br1 br3-l" src="https://minotar.net/avatar/069a79f444e94726a5befca90e38aaf5/64" alt="The Avatar of Notch" title="Notch">
+                    </div>
+                    <div class="mr3 dn db-ns">
+                        <img class="grow db br1 br3-l" src="https://minotar.net/avatar/0916866379734076877df789dd30340b/64" alt="The Avatar of Banxsi" title="Banxsi">
+                    </div>
+                    <div class="mr3 dn db-ns">
+                        <img class="grow db br1 br3-l" src="https://minotar.net/avatar/472cdef3cef147a0a44a2ab7f5ce07f6/64" alt="The Avatar of externo6" title="externo6">
+                    </div>
+                    <div class="mr3 dn db-ns">
+                        <img class="grow db br1 br3-l" src="https://minotar.net/avatar/0c035b597e1a42b0b31610c9343d34dd/64" alt="The Avatar of drupal" title="drupal">
                     </div>
                     <div class="">
-                        <img class="grown db br3" src="https://minotar.net/avatar/7d043c7389524696bfba571c05b6aec0/64.png" alt="The Avatar of ez" title="ez">
+                        <img class="grow db br1 br3-l" src="https://minotar.net/avatar/7d043c7389524696bfba571c05b6aec0/64" alt="The Avatar of ez" title="ez">
                     </div>
                 </div>
             </div>
@@ -90,8 +89,14 @@
                 <h2>Username and UUID support!</h2>
 
                 <p>Just send us a Username or UUID. The UUID can either be plain or dashed (though we will redirect to plain).</p>
-                <p><span class="i">Usernames may be deprecated in the future.</span></p>
-                <p class="pl2 bl bw1 b--light-red b">Replace <span class="blue">user</span> with the Username/UUID</p>
+                <ul class="list">
+                    <li><span class="blue">LukeHandle</span> <span class="b green">&check;<span class="dn di-ns"> OK</span></span></li>
+                    <li><span class="blue">5c115ca7-3efd-4117-8213-a0aff8ef11e0</span> <span class="b light-green">&Tilde;<span class="dn di-ns"> REDIRECTS &DoubleRightArrow;</span></span></li>
+                    <li><span class="blue">5c115ca73efd41178213a0aff8ef11e0</span> <span class="b dark-green">&check;<span class="dn di-ns"> GREAT</span></span></li>
+                </ul>
+                <p><span class="i">Usernames may be deprecated in the future and are more susceptible to rate limits.</span></p>
+                <p class="pl2 bl bw1 b--light-red b">Replace <span class="blue">user</span> with the Username/UUID in the below examples</p>
+
             </div>
         </div>
 
@@ -101,13 +106,14 @@
 
                 <p>For basic usage, provide a username or UUID in the
                     <span class="blue">user</span> field:</p>
-                <pre class="pa3 bg-washed-red">&lt;img src="https://minotar.net/avatar/<span class="blue">user</span>"&gt;</pre>
+                <pre class="pa3 bg-washed-red overflow-scroll">https://minotar.net/avatar/<span class="blue">user</span></pre>
                 <p>You can also set a size. We use pixels and only need the
                     <span class="red">width</span>. Just add it to the end.</p>
-                <pre class="pa3 bg-washed-red">&#60;img src="https://minotar.net/avatar/<span class="blue">user</span>/<span class="red">100</span>"&#62;</pre>
+                <pre class="pa3 bg-washed-red overflow-scroll">https://minotar.net/avatar/<span class="blue">user</span>/<span class="red">100</span></pre>
                 <p>And because some services require an extension, we've added simple support for it. Just add
                     <span class="green">.png</span> to the end.</p>
-                <pre class="pa3 bg-washed-red">&#60;img src="https://minotar.net/avatar/<span class="blue">user</span>/<span class="red">100</span><span class="green">.png</span>"&#62;</pre>
+                <pre class="pa3 bg-washed-red overflow-scroll">https://minotar.net/avatar/<span class="blue">user</span><span class="green">.png</span>
+https://minotar.net/avatar/<span class="blue">user</span>/<span class="red">100</span><span class="green">.png</span></pre>
             </div>
             <div class="mt4-l w-100 w-25-l fl tc tr-l">
                 <img class="dib ba br1 b--washed-red pa2" src="https://minotar.net/avatar/d9135e082f2244c89cb0bee234155292/128" alt="The Avatar of clone1018" title="clone1018's Avatar">
@@ -119,7 +125,7 @@
                 <h2>Avatar With Helm</h2>
 
                 <p>Sometimes you want to display a helm too, that's fine with this endpoint:</p>
-                <pre class="pa3 bg-washed-red">&#60;img src="https://minotar.net/helm/<span class="blue">user</span>/<span class="red">100</span><span class="green">.png</span>"&#62;</pre>
+                <pre class="pa3 bg-washed-red overflow-scroll">https://minotar.net/helm/<span class="blue">user</span>/<span class="red">100</span><span class="green">.png</span></pre>
             </div>
             <div class="mt4-l w-100 w-25-l fl tc tr-l">
                 <img class="dib ba br1 b--washed-red pa2" src="https://minotar.net/helm/5c115ca73efd41178213a0aff8ef11e0/128" alt="The Helmet of LukeHandle" title="LukeHandle's Helmet">
@@ -131,7 +137,7 @@
                 <h2>Isometric Head</h2>
 
                 <p>A cube head for a cube game.</p>
-                <pre class="pa3 bg-washed-red">&#60;img src="https://minotar.net/cube/<span class="blue">user</span>/<span class="red">100</span><span class="green">.png</span>"&#62;</pre>
+                <pre class="pa3 bg-washed-red overflow-scroll">https://minotar.net/cube/<span class="blue">user</span>/<span class="red">100</span><span class="green">.png</span></pre>
             </div>
             <div class="mt4-l w-100 w-25-l fl tc tr-l">
                 <img class="dib ba br1 b--washed-red pa2" src="https://minotar.net/cube/48a0a7e4d5594873a617dc189f76a8a1/128" alt="The Cube Avatar of citricsquid" title="citricsquid's Cube Avatar">
@@ -143,10 +149,10 @@
                 <h2>Body</h2>
 
                 <p>A full frontal.</p>
-                <pre class="pa3 bg-washed-red">&#60;img src="https://minotar.net/body/<span class="blue">user</span>/<span class="red">100</span><span class="green">.png</span>"&#62;</pre>
+                <pre class="pa3 bg-washed-red overflow-scroll">https://minotar.net/body/<span class="blue">user</span>/<span class="red">100</span><span class="green">.png</span></pre>
                 <p>
                     <small class="b">New!</small> An armored full frontal.</p>
-                <pre class="pa3 bg-washed-red">&#60;img src="https://minotar.net/armor/body/<span class="blue">user</span>/<span class="red">100</span><span class="green">.png</span>"&#62;</pre>
+                <pre class="pa3 bg-washed-red overflow-scroll">https://minotar.net/armor/body/<span class="blue">user</span>/<span class="red">100</span><span class="green">.png</span></pre>
             </div>
             <div class="mt4-l w-100 w-25-l fl">
                 <div class="flex flex-row center justify-center justify-end-l">
@@ -161,10 +167,10 @@
                 <h2>Bust</h2>
 
                 <p>If you prefer the bust.</p>
-                <pre class="pa3 bg-washed-red">&#60;img src="https://minotar.net/bust/<span class="blue">user</span>/<span class="red">100</span><span class="green">.png</span>"&#62;</pre>
+                <pre class="pa3 bg-washed-red overflow-scroll">https://minotar.net/bust/<span class="blue">user</span>/<span class="red">100</span><span class="green">.png</span></pre>
                 <p>
                     <small class="b">New!</small> If you like to protect your bust.</p>
-                <pre class="pa3 bg-washed-red">&#60;img src="https://minotar.net/armor/bust/<span class="blue">user</span>/<span class="red">100</span><span class="green">.png</span>"&#62;</pre>
+                <pre class="pa3 bg-washed-red overflow-scroll">https://minotar.net/armor/bust/<span class="blue">user</span>/<span class="red">100</span><span class="green">.png</span></pre>
             </div>
             <div class="mt4-l w-100 w-25-l fl">
                 <div class="flex flex-row center justify-center justify-end-l">
@@ -181,9 +187,9 @@
                 <p>You can even use Minotar's API to get a users skin.
                     <em>We're adding more soon!</em>
                 </p>
-                <pre class="pa3 bg-washed-red">&#60;img src="https://minotar.net/skin/<span class="blue">user</span>"&#62;</pre>
+                <pre class="pa3 bg-washed-red overflow-scroll">https://minotar.net/skin/<span class="blue">user</span></pre>
                 <p>You can also set the browser to download the image by using:</p>
-                <pre class="pa3 bg-washed-red">https://minotar.net/download/<span class="blue">user</span></pre>
+                <pre class="pa3 bg-washed-red overflow-scroll">https://minotar.net/download/<span class="blue">user</span></pre>
             </div>
             <div class="mt4-l w-100 w-25-l fl tc tr-l">
                 <img class="dib ba br1 b--washed-red pa2" src="https://minotar.net/skin/2f3665cc5e29439bbd14cb6d3a6313a7" style="width:196px" alt="The Skin of lukegb" title="lukegb's Skin">
@@ -195,7 +201,7 @@
                 <h2>Default Skin</h2>
 
                 <p>Need Steve? Use "<span class="blue b">MHF_Steve</span>" as the username:</p>
-                <pre class="pa3 bg-washed-red">&#60;img src="https://minotar.net/skin/<span class="blue">MHF_Steve</span>"&#62;</pre>
+                <pre class="pa3 bg-washed-red overflow-scroll">https://minotar.net/skin/<span class="blue">MHF_Steve</span></pre>
             </div>
             <div class="mt4-l w-100 w-25-l fl tc tr-l">
                 <img class="dib ba br1 b--washed-red pa2" src="https://minotar.net/skin/c06f89064c8a49119c29ea1dbd1aab82" style="width:196px" alt="The Skin of MHF_Steve" title="MHF_Steve's Skin">
@@ -208,13 +214,17 @@
                 <h2 class="f2 fw6">Minotar</h2>
 
                 <p>Copyright 2018 &mdash;
-                    <a href="http://axxim.net" class="link washed-red bb dim">Axxim, LLC</a>
+                    <a href="http://axxim.net/" class="link washed-red underline dim">Axxim, LLC</a>
                 </p>
                 <p>Hosted by
-                    <a href="https://www.digitalocean.com" class="link washed-red bb dim">DigitalOcean</a>
+                    <a href="https://www.digitalocean.com/" class="link washed-red underline dim">DigitalOcean
+                        <svg class="h1" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="65.2 173.5 180 180"><path d="M155.2 351.7v-34.2c36.2 0 64.3-35.9 50.4-74-5.1-14.1-16.4-25.4-30.5-30.5-38.1-13.8-74 14.2-74 50.4H67c0-57.7 55.8-102.7 116.3-83.8 26.4 8.3 47.5 29.3 55.7 55.7 18.9 60.6-26 116.4-83.8 116.4z" class="st0"/><path d="M155.3 317.6h-34v-34h34zM121.3 343.8H95.1v-26.2h26.2zM95.1 317.6H73.2v-21.9h21.9v21.9z" class="st0"/></svg>
+                    </a>
                 </p>
                 <p>Open source on
-                    <a href="https://github.com/minotar/imgd" class="link washed-red bb dim">GitHub</a>
+                    <a href="https://github.com/minotar/imgd" class="link washed-red underline dim">GitHub
+                        <svg class="h1" xmlns="http://www.w3.org/2000/svg" fill="currentColor" fill-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="1.414" clip-rule="evenodd" viewBox="0 0 16 16"><path d="M8 0a8 8 0 0 0-8 8 8 8 0 0 0 5.47 7.59c.4.075.547-.172.547-.385 0-.19-.007-.693-.01-1.36-2.226.483-2.695-1.073-2.695-1.073-.364-.924-.89-1.17-.89-1.17-.725-.496.056-.486.056-.486.803.056 1.225.824 1.225.824.714 1.223 1.873.87 2.33.665.072-.517.278-.87.507-1.07-1.777-.2-3.644-.888-3.644-3.953 0-.873.31-1.587.823-2.147-.083-.202-.358-1.015.077-2.117 0 0 .672-.215 2.2.82a7.68 7.68 0 0 1 2.003-.27c.68.004 1.364.092 2.003.27 1.527-1.035 2.198-.82 2.198-.82.437 1.102.163 1.915.08 2.117.513.56.823 1.274.823 2.147 0 3.073-1.87 3.75-3.653 3.947.287.246.543.735.543 1.48 0 1.07-.01 1.933-.01 2.195 0 .215.144.463.55.385A8 8 0 0 0 8 0"/></svg>
+                    </a>
                 </p>
             </div>
             <div>


### PR DESCRIPTION
* Add icons for DigitalOcean and GitHub
* Typo on "grow"
* Add Username/UUID examples
* Standardise on no `.png` extension on images
* Change examples to be just the URL vs. HTML embed example
* `pre` should overflow/scroll right
* Hide @connor4312's avatar vs. @clone1018's on mobile (if we had a UUID/valid skin, then we could hide somebody else instead :crying_cat_face: )